### PR TITLE
Adding name parsing to the eamSetfl case.

### DIFF
--- a/src-mpi/eam.c
+++ b/src-mpi/eam.c
@@ -640,8 +640,13 @@ void eamReadSetfl(EamPotential* pot, const char* dir, const char* potName)
    if (potFile == NULL)
       fileNotFound("eamReadSetfl", tmp);
    
-   // read the first 3 lines (comments)
+   // get the name from line 1
    fgets(tmp, sizeof(tmp), potFile);
+   char name[3];
+   sscanf(tmp, "%s", name);
+   strcpy(pot->name, name);
+
+   // read the next 2 lines (comments)
    fgets(tmp, sizeof(tmp), potFile);
    fgets(tmp, sizeof(tmp), potFile);
 


### PR DESCRIPTION
The default behavior for eamReadSetfl does not populate the name field of the EamPotential struct, which caused a buffer overflow when running with "mpirun -n 1 ./bin/CoMD-mpi -e -t setfl -p Cu01.eam.alloy"

The comments claim that the first three lines are comments, but the first line of Cu01.eam.alloy looks similar to that of Cu_u6.eam.
